### PR TITLE
Improve json reader

### DIFF
--- a/src/main/java/org/jabref/logic/importer/IdBasedParserFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/IdBasedParserFetcher.java
@@ -34,13 +34,6 @@ public interface IdBasedParserFetcher extends IdBasedFetcher {
     URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException;
 
     /**
-     * Constructs an URL-Download for the given identifier. As default, it uses {@link #getUrlForIdentifier(String)} to obtain the URL
-     */
-    default URLDownload getUrlDownloadForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
-        return new URLDownload(getUrlForIdentifier(identifier));
-    }
-
-    /**
      * Returns the parser used to convert the response to a list of {@link BibEntry}.
      */
     Parser getParser();
@@ -68,7 +61,7 @@ public interface IdBasedParserFetcher extends IdBasedFetcher {
             return Optional.empty();
         }
 
-        try (InputStream stream = getUrlDownloadForIdentifier(identifier).asInputStream()) {
+        try (InputStream stream = getUrlDownload(getUrlForIdentifier(identifier)).asInputStream()) {
             List<BibEntry> fetchedEntries = getParser().parseEntries(stream);
 
             if (fetchedEntries.isEmpty()) {

--- a/src/main/java/org/jabref/logic/importer/IdBasedParserFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/IdBasedParserFetcher.java
@@ -31,7 +31,14 @@ public interface IdBasedParserFetcher extends IdBasedFetcher {
      *
      * @param identifier the ID
      */
-    URL getURLForID(String identifier) throws URISyntaxException, MalformedURLException, FetcherException;
+    URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException;
+
+    /**
+     * Constructs an URL-Download for the given identifier. As default, it uses {@link #getUrlForIdentifier(String)} to obtain the URL
+     */
+    default URLDownload getUrlDownloadForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+        return new URLDownload(getUrlForIdentifier(identifier));
+    }
 
     /**
      * Returns the parser used to convert the response to a list of {@link BibEntry}.
@@ -61,7 +68,7 @@ public interface IdBasedParserFetcher extends IdBasedFetcher {
             return Optional.empty();
         }
 
-        try (InputStream stream = new URLDownload(getURLForID(identifier)).asInputStream()) {
+        try (InputStream stream = getUrlDownloadForIdentifier(identifier).asInputStream()) {
             List<BibEntry> fetchedEntries = getParser().parseEntries(stream);
 
             if (fetchedEntries.isEmpty()) {

--- a/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
@@ -43,6 +43,7 @@ public interface SearchBasedParserFetcher extends SearchBasedFetcher {
      * {@code new FieldFormatterCleanup(StandardField.TITLE, new RemoveBracesFormatter()).cleanup(entry);}
      *
      * By default, no cleanup is done.
+     *
      * @param entry the entry to be cleaned-up
      */
     default void doPostCleanup(BibEntry entry) {
@@ -50,14 +51,11 @@ public interface SearchBasedParserFetcher extends SearchBasedFetcher {
     }
 
     /**
-     * Gets the {@link URLDownload} object for downloading content. Overwrite, if you need to send additional headers for the download
+     * Gets the {@link URLDownload} object for downloading content. Overwrite, if you need to send additional headers for the download. It uses {@link #getURLForQuery(String)} as default.
      *
      * @param query The search query
-     * @throws MalformedURLException
-     * @throws FetcherException
-     * @throws URISyntaxException
      */
-    default URLDownload getUrlDownload(String query) throws MalformedURLException, FetcherException, URISyntaxException {
+    default URLDownload getUrlDownloadForQuery(String query) throws MalformedURLException, FetcherException, URISyntaxException {
         return new URLDownload(getURLForQuery(query));
     }
 
@@ -67,7 +65,7 @@ public interface SearchBasedParserFetcher extends SearchBasedFetcher {
             return Collections.emptyList();
         }
 
-        try (InputStream stream = getUrlDownload(query).asInputStream()) {
+        try (InputStream stream = getUrlDownloadForQuery(query).asInputStream()) {
             List<BibEntry> fetchedEntries = getParser().parseEntries(stream);
 
             // Post-cleanup

--- a/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
@@ -50,22 +50,13 @@ public interface SearchBasedParserFetcher extends SearchBasedFetcher {
         // Do nothing by default
     }
 
-    /**
-     * Gets the {@link URLDownload} object for downloading content. Overwrite, if you need to send additional headers for the download. It uses {@link #getURLForQuery(String)} as default.
-     *
-     * @param query The search query
-     */
-    default URLDownload getUrlDownloadForQuery(String query) throws MalformedURLException, FetcherException, URISyntaxException {
-        return new URLDownload(getURLForQuery(query));
-    }
-
     @Override
     default List<BibEntry> performSearch(String query) throws FetcherException {
         if (StringUtil.isBlank(query)) {
             return Collections.emptyList();
         }
 
-        try (InputStream stream = getUrlDownloadForQuery(query).asInputStream()) {
+        try (InputStream stream = getUrlDownload(getURLForQuery(query)).asInputStream()) {
             List<BibEntry> fetchedEntries = getParser().parseEntries(stream);
 
             // Post-cleanup

--- a/src/main/java/org/jabref/logic/importer/WebFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetcher.java
@@ -1,8 +1,10 @@
 package org.jabref.logic.importer;
 
+import java.net.URL;
 import java.util.Optional;
 
 import org.jabref.logic.help.HelpFile;
+import org.jabref.logic.net.URLDownload;
 
 /**
  * Searches web resources for bibliographic information.
@@ -24,5 +26,12 @@ public interface WebFetcher {
      */
     default Optional<HelpFile> getHelpPage() {
         return Optional.empty(); // no help page by default
+    }
+
+    /**
+     * Constructs an {@link URLDownload} object for downloading content based on the given URL. Overwrite, if you need to send additional headers for the download.
+     */
+    default URLDownload getUrlDownload(URL url) {
+        return new URLDownload(url);
     }
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
@@ -121,7 +121,7 @@ public class AstrophysicsDataSystem implements IdBasedParserFetcher, SearchBased
      * @return URL which points to a search URL for given identifier
      */
     @Override
-    public URL getURLForID(String identifier) throws FetcherException, URISyntaxException, MalformedURLException {
+    public URL getUrlForIdentifier(String identifier) throws FetcherException, URISyntaxException, MalformedURLException {
         String query = "doi:\"" + identifier + "\" OR " + "bibcode:\"" + identifier + "\"";
         URIBuilder builder = new URIBuilder(API_SEARCH_URL);
         builder.addParameter("q", query);
@@ -227,7 +227,7 @@ public class AstrophysicsDataSystem implements IdBasedParserFetcher, SearchBased
         }
 
         try {
-            List<String> bibcodes = fetchBibcodes(getURLForID(identifier));
+            List<String> bibcodes = fetchBibcodes(getUrlForIdentifier(identifier));
             List<BibEntry> fetchedEntries = performSearchByIds(bibcodes);
 
             if (fetchedEntries.isEmpty()) {

--- a/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
@@ -1,8 +1,5 @@
 package org.jabref.logic.importer.fetcher;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PushbackInputStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -21,7 +18,6 @@ import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.SearchBasedParserFetcher;
 import org.jabref.logic.importer.util.JsonReader;
-import org.jabref.logic.net.URLDownload;
 import org.jabref.logic.util.strings.StringSimilarity;
 import org.jabref.model.cleanup.FieldFormatterCleanup;
 import org.jabref.model.entry.AuthorList;
@@ -30,7 +26,6 @@ import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.entry.types.StandardEntryType;
-import org.jabref.model.strings.StringUtil;
 import org.jabref.model.util.OptionalUtil;
 
 import kong.unirest.json.JSONArray;

--- a/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
@@ -7,6 +7,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,7 +75,7 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
     }
 
     @Override
-    public URL getURLForID(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+    public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
         URIBuilder uriBuilder = new URIBuilder(API_URL + "/" + identifier);
         return uriBuilder.build().toURL();
     }
@@ -82,63 +83,32 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
     @Override
     public Parser getParser() {
         return inputStream -> {
-            JSONObject response = JsonReader.toJsonObject(inputStream).getJSONObject("message");
+            JSONObject response = JsonReader.toJsonObject(inputStream);
+            if (response.isEmpty()) {
+                return Collections.emptyList();
+            }
 
-            List<BibEntry> entries = new ArrayList<>();
-            if (response.has("items")) {
-                // Response contains a list
-                JSONArray items = response.getJSONArray("items");
-                for (int i = 0; i < items.length(); i++) {
-                    JSONObject item = items.getJSONObject(i);
-                    BibEntry entry = jsonItemToBibEntry(item);
-                    entries.add(entry);
-                }
-            } else {
+            response = response.getJSONObject("message");
+            if (response.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            if (!response.has("items")) {
                 // Singleton response
                 BibEntry entry = jsonItemToBibEntry(response);
+                return Collections.singletonList(entry);
+            }
+
+            // Response contains a list
+            JSONArray items = response.getJSONArray("items");
+            List<BibEntry> entries = new ArrayList<>(items.length());
+            for (int i = 0; i < items.length(); i++) {
+                JSONObject item = items.getJSONObject(i);
+                BibEntry entry = jsonItemToBibEntry(item);
                 entries.add(entry);
             }
-
             return entries;
         };
-    }
-
-    @Override
-    public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
-        if (StringUtil.isBlank(identifier)) {
-            return Optional.empty();
-        }
-
-        try (InputStream stream = new URLDownload(getURLForID(identifier)).asInputStream();
-             PushbackInputStream pushbackInputStream = new PushbackInputStream(stream)) {
-
-            List<BibEntry> fetchedEntries = new ArrayList<>();
-
-            // check if there is anything to read
-            int readByte;
-            readByte = pushbackInputStream.read();
-            if (readByte != -1) {
-                pushbackInputStream.unread(readByte);
-                fetchedEntries = getParser().parseEntries(pushbackInputStream);
-            }
-
-            if (fetchedEntries.isEmpty()) {
-                return Optional.empty();
-            }
-
-            BibEntry entry = fetchedEntries.get(0);
-
-            // Post-cleanup
-            doPostCleanup(entry);
-
-            return Optional.of(entry);
-        } catch (URISyntaxException e) {
-            throw new FetcherException("Search URI is malformed", e);
-        } catch (IOException e) {
-            throw new FetcherException("A network error occurred", e);
-        } catch (ParseException e) {
-            throw new FetcherException("An internal parser error occurred", e);
-        }
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/importer/fetcher/DiVA.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DiVA.java
@@ -38,7 +38,7 @@ public class DiVA implements IdBasedParserFetcher {
     }
 
     @Override
-    public URL getURLForID(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+    public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
         URIBuilder uriBuilder = new URIBuilder("http://www.diva-portal.org/smash/getreferences");
 
         uriBuilder.addParameter("referenceFormat", "BibTex");

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
@@ -14,6 +14,7 @@ import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.IdBasedFetcher;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ParseException;
+import org.jabref.logic.importer.WebFetcher;
 import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.logic.importer.util.MediaTypes;
 import org.jabref.logic.l10n.Localization;
@@ -69,7 +70,7 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
                 URL doiURL = new URL(doi.get().getURIAsASCIIString());
 
                 // BibTeX data
-                URLDownload download = new URLDownload(doiURL);
+                URLDownload download = getUrlDownload(doiURL);
                 download.addHeader("Accept", MediaTypes.APPLICATION_BIBTEX);
                 String bibtexString = download.asString();
 
@@ -108,24 +109,20 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
     /**
      * Returns registration agency. Optional.empty() if no agency is found.
      *
-     * @param doi the doi to be searched
+     * @param doi the DOI to be searched
      */
     public Optional<String> getAgency(DOI doi) throws IOException {
         Optional<String> agency = Optional.empty();
-
         try {
-            URLDownload download = new URLDownload(new URL(DOI.AGENCY_RESOLVER + "/" + doi.getDOI()));
+            URLDownload download = getUrlDownload(new URL(DOI.AGENCY_RESOLVER + "/" + doi.getDOI()));
             JSONObject response = new JSONArray(download.asString()).getJSONObject(0);
-
             if (response != null) {
                 agency = Optional.ofNullable(response.optString("RA"));
             }
-
         } catch (JSONException e) {
             LOGGER.error("Cannot parse agency fetcher repsonse to JSON");
             return Optional.empty();
         }
-
 
         return agency;
     }

--- a/src/main/java/org/jabref/logic/importer/fetcher/INSPIREFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/INSPIREFetcher.java
@@ -54,7 +54,7 @@ public class INSPIREFetcher implements SearchBasedParserFetcher {
     }
 
     @Override
-    public URLDownload getUrlDownload(String query) throws MalformedURLException, FetcherException, URISyntaxException {
+    public URLDownload getUrlDownloadForQuery(String query) throws MalformedURLException, FetcherException, URISyntaxException {
         URLDownload download = new URLDownload(getURLForQuery(query));
         download.addHeader("Accept", MediaTypes.APPLICATION_BIBTEX);
         return download;

--- a/src/main/java/org/jabref/logic/importer/fetcher/INSPIREFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/INSPIREFetcher.java
@@ -54,8 +54,8 @@ public class INSPIREFetcher implements SearchBasedParserFetcher {
     }
 
     @Override
-    public URLDownload getUrlDownloadForQuery(String query) throws MalformedURLException, FetcherException, URISyntaxException {
-        URLDownload download = new URLDownload(getURLForQuery(query));
+    public URLDownload getUrlDownload(URL url) {
+        URLDownload download = new URLDownload(url);
         download.addHeader("Accept", MediaTypes.APPLICATION_BIBTEX);
         return download;
     }

--- a/src/main/java/org/jabref/logic/importer/fetcher/IsbnViaEbookDeFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IsbnViaEbookDeFetcher.java
@@ -30,7 +30,7 @@ public class IsbnViaEbookDeFetcher extends AbstractIsbnFetcher {
     }
 
     @Override
-    public URL getURLForID(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+    public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
         this.ensureThatIsbnIsValid(identifier);
         URIBuilder uriBuilder = new URIBuilder(BASE_URL);
         uriBuilder.addParameter("isbn", identifier);

--- a/src/main/java/org/jabref/logic/importer/fetcher/IsbnViaOttoBibFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IsbnViaOttoBibFetcher.java
@@ -39,7 +39,7 @@ public class IsbnViaOttoBibFetcher extends AbstractIsbnFetcher {
      * @return null, because the identifier is passed using form data. This method is not used.
      */
     @Override
-    public URL getURLForID(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+    public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
         return null;
     }
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/LibraryOfCongress.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/LibraryOfCongress.java
@@ -29,7 +29,7 @@ public class LibraryOfCongress implements IdBasedParserFetcher {
     }
 
     @Override
-    public URL getURLForID(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+    public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
         URIBuilder uriBuilder = new URIBuilder("https://lccn.loc.gov/" + identifier + "/mods");
         return uriBuilder.build().toURL();
     }

--- a/src/main/java/org/jabref/logic/importer/fetcher/MathSciNet.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/MathSciNet.java
@@ -57,7 +57,7 @@ public class MathSciNet implements SearchBasedParserFetcher, EntryBasedParserFet
         Optional<String> mrNumberInEntry = entry.getField(StandardField.MR_NUMBER);
         if (mrNumberInEntry.isPresent()) {
             // We are lucky and already know the id, so use it instead
-            return getURLForID(mrNumberInEntry.get());
+            return getUrlForIdentifier(mrNumberInEntry.get());
         }
 
         URIBuilder uriBuilder = new URIBuilder("https://mathscinet.ams.org/mrlookup");
@@ -83,7 +83,7 @@ public class MathSciNet implements SearchBasedParserFetcher, EntryBasedParserFet
     }
 
     @Override
-    public URL getURLForID(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+    public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
         URIBuilder uriBuilder = new URIBuilder("https://mathscinet.ams.org/mathscinet/search/publications.html");
         uriBuilder.addParameter("pg1", "MR"); // search MR number
         uriBuilder.addParameter("s1", identifier); // identifier

--- a/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
@@ -135,7 +135,7 @@ public class MedlineFetcher implements IdBasedParserFetcher, SearchBasedFetcher 
     }
 
     @Override
-    public URL getURLForID(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+    public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
         URIBuilder uriBuilder = new URIBuilder(ID_URL);
         uriBuilder.addParameter("db", "pubmed");
         uriBuilder.addParameter("retmode", "xml");
@@ -206,7 +206,7 @@ public class MedlineFetcher implements IdBasedParserFetcher, SearchBasedFetcher 
     private List<BibEntry> fetchMedline(List<String> ids) throws FetcherException {
         try {
             // Separate the IDs with a comma to search multiple entries
-            URL fetchURL = getURLForID(String.join(",", ids));
+            URL fetchURL = getUrlForIdentifier(String.join(",", ids));
             URLConnection data = fetchURL.openConnection();
             ParserResult result = new MedlineImporter().importDatabase(
                     new BufferedReader(new InputStreamReader(data.getInputStream(), StandardCharsets.UTF_8)));

--- a/src/main/java/org/jabref/logic/importer/fetcher/Medra.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/Medra.java
@@ -1,14 +1,9 @@
 package org.jabref.logic.importer.fetcher;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PushbackInputStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import org.jabref.logic.importer.FetcherException;
@@ -23,12 +18,10 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.entry.types.StandardEntryType;
-import org.jabref.model.strings.StringUtil;
 
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONException;
 import kong.unirest.json.JSONObject;
-import org.apache.http.client.utils.URIBuilder;
 
 /**
  * A class for fetching DOIs from Medra
@@ -50,7 +43,9 @@ public class Medra implements IdBasedParserFetcher {
     public Parser getParser() {
         return inputStream -> {
             JSONObject response = JsonReader.toJsonObject(inputStream);
-
+            if (response.isEmpty()) {
+                return Collections.emptyList();
+            }
             return Collections.singletonList(jsonItemToBibEntry(response));
         };
     }
@@ -114,60 +109,15 @@ public class Medra implements IdBasedParserFetcher {
     }
 
     @Override
-    public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
-        if (StringUtil.isBlank(identifier)) {
-            return Optional.empty();
-        }
-
-        try (InputStream stream = getUrlDownload(identifier).asInputStream();
-             PushbackInputStream pushbackInputStream = new PushbackInputStream(stream)) {
-
-            List<BibEntry> fetchedEntries = new ArrayList<>();
-
-            // check if there is anything to read
-            int readByte;
-            readByte = pushbackInputStream.read();
-            if (readByte != -1) {
-                pushbackInputStream.unread(readByte);
-                fetchedEntries = getParser().parseEntries(pushbackInputStream);
-            }
-
-            if (fetchedEntries.isEmpty()) {
-                return Optional.empty();
-            }
-
-            BibEntry entry = fetchedEntries.get(0);
-
-            // Post-cleanup
-            doPostCleanup(entry);
-
-            return Optional.of(entry);
-        } catch (URISyntaxException e) {
-            throw new FetcherException("Search URI is malformed", e);
-        } catch (IOException e) {
-            // For some DOIs we get 500 error. mEDRA team explained this is due to DOIs recently moved from other agency but no yet fully registered.
-            // They say these should return 204 code and they will fix the misconfiguration
-            throw new FetcherException("A network error occurred", e);
-        } catch (ParseException e) {
-            throw new FetcherException("An internal parser error occurred", e);
-        }
-    }
-
-    @Override
-    public void doPostCleanup(BibEntry entry) {
-        IdBasedParserFetcher.super.doPostCleanup(entry);
-    }
-
-    public URLDownload getUrlDownload(String identifier) throws MalformedURLException, FetcherException, URISyntaxException {
-        URLDownload download = new URLDownload(getURLForID(identifier));
+    public URLDownload getUrlDownloadForIdentifier(String identifier) throws MalformedURLException, FetcherException, URISyntaxException {
+        URLDownload download = new URLDownload(getUrlForIdentifier(identifier));
         download.addHeader("Accept", MediaTypes.CITATIONSTYLES_JSON);
         return download;
     }
 
     @Override
-    public URL getURLForID(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
-        URIBuilder uriBuilder = new URIBuilder(API_URL + "/" + identifier);
-        return uriBuilder.build().toURL();
+    public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+        return new URL(API_URL + "/" + identifier);
     }
 
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/Medra.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/Medra.java
@@ -95,15 +95,12 @@ public class Medra implements IdBasedParserFetcher {
 
         for (int i = 0; i < authors.length(); i++) {
             JSONObject author = authors.getJSONObject(i);
-            name = author.optString("literal", "") + " " + author.optString("family", "") + " " + author.optString("given", "");
-
-            authorsParsed.addAuthor(
-                                    name,
-                                    "",
-                                    "",
-                                    "",
-                                    "");
-
+            if (author.has("literal")) {
+                // quickly route through the literal string
+                authorsParsed.addAuthor(author.getString("literal"), "", "", "", "");
+            } else {
+                authorsParsed.addAuthor(author.optString("given", ""), "", "", author.optString("family", ""), "");
+            }
         }
         return authorsParsed.getAsFirstLastNamesWithAnd();
     }

--- a/src/main/java/org/jabref/logic/importer/fetcher/Medra.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/Medra.java
@@ -106,8 +106,8 @@ public class Medra implements IdBasedParserFetcher {
     }
 
     @Override
-    public URLDownload getUrlDownloadForIdentifier(String identifier) throws MalformedURLException, FetcherException, URISyntaxException {
-        URLDownload download = new URLDownload(getUrlForIdentifier(identifier));
+    public URLDownload getUrlDownload(URL url) {
+        URLDownload download = new URLDownload(url);
         download.addHeader("Accept", MediaTypes.CITATIONSTYLES_JSON);
         return download;
     }

--- a/src/main/java/org/jabref/logic/importer/fetcher/RfcFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/RfcFetcher.java
@@ -39,7 +39,7 @@ public class RfcFetcher implements IdBasedParserFetcher {
     }
 
     @Override
-    public URL getURLForID(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+    public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
         // Add "rfc" prefix if user's search entry was numerical
         String prefixedIdentifier = identifier;
         prefixedIdentifier = (!identifier.toLowerCase().startsWith("rfc")) ? "rfc" + prefixedIdentifier : prefixedIdentifier;

--- a/src/main/java/org/jabref/logic/importer/util/JsonReader.java
+++ b/src/main/java/org/jabref/logic/importer/util/JsonReader.java
@@ -1,13 +1,13 @@
 package org.jabref.logic.importer.util;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 
 import org.jabref.logic.importer.ParseException;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.ByteStreams;
+import kong.unirest.json.JSONException;
 import kong.unirest.json.JSONObject;
 
 /**
@@ -15,25 +15,21 @@ import kong.unirest.json.JSONObject;
  */
 public class JsonReader {
 
-    public static JSONObject toJsonObject(InputStreamReader input) throws ParseException {
-        BufferedReader streamReader = new BufferedReader(input);
-        StringBuilder responseStrBuilder = new StringBuilder();
-
+    /**
+     * Converts the given input stream into a {@link JSONObject}.
+     *
+     * @return A {@link JSONObject}. An empty JSON object is returned in the case an empty stream is passed.
+     */
+    public static JSONObject toJsonObject(InputStream inputStream) throws ParseException {
         try {
-            String inputStr;
-            while ((inputStr = streamReader.readLine()) != null) {
-                responseStrBuilder.append(inputStr);
+            String inputStr = new String(ByteStreams.toByteArray(inputStream), Charsets.UTF_8);
+            // Fallback: in case an empty stream was passed, return an empty JSON object
+            if (inputStr.isBlank()) {
+                return new JSONObject();
             }
-            if (responseStrBuilder.toString().isBlank()) {
-                throw new ParseException("Empty input!");
-            }
-            return new JSONObject(responseStrBuilder.toString());
-        } catch (IOException e) {
+            return new JSONObject(inputStr);
+        } catch (IOException | JSONException e) {
             throw new ParseException(e);
         }
-    }
-
-    public static JSONObject toJsonObject(InputStream input) throws ParseException {
-        return toJsonObject(new InputStreamReader(input, StandardCharsets.UTF_8));
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/CrossRefTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CrossRefTest.java
@@ -140,7 +140,9 @@ public class CrossRefTest {
         assertEquals(Collections.emptyList(), fetcher.performSearch(""));
     }
 
-    // test added to reveal fetching error on crossref performSearchById -- caldarola
+    /**
+     * reveal fetching error on crossref performSearchById
+     */
     @Test
     public void testPerformSearchValidReturnNothingDOI() throws FetcherException {
         assertEquals(Optional.empty(), fetcher.performSearchById("10.1392/BC1.0"));

--- a/src/test/java/org/jabref/logic/importer/fetcher/MedraTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MedraTest.java
@@ -1,69 +1,76 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MedraTest {
 
-    private Medra fetcher;
-    private BibEntry bibEntrySpileers2018;
-    private BibEntry bibEntryIannarelli2019;
-    private BibEntry bibEntryCisternino1999;
+    private Medra fetcher = new Medra();
 
-    @BeforeEach
-    public void setUp() {
-        fetcher = new Medra();
+    private static Stream<Arguments> getDoiBibEntryPairs() {
+        return Stream.of(
+                Arguments.of("10.1016/j.bjoms.2007.08.004",
+                        Optional.empty()),
 
-        bibEntrySpileers2018 = new BibEntry();
-        bibEntrySpileers2018.setType(StandardEntryType.Article);
-        bibEntrySpileers2018.setField(StandardField.AUTHOR, "SPILEERS, Steven ");
-        bibEntrySpileers2018.setField(StandardField.PUBLISHER, "Peeters online journals");
-        bibEntrySpileers2018.setField(StandardField.TITLE, "Algemene kroniek");
-        bibEntrySpileers2018.setField(StandardField.YEAR, "2018");
-        bibEntrySpileers2018.setField(StandardField.DOI, "10.2143/TVF.80.3.3285690");
-        bibEntrySpileers2018.setField(StandardField.ISSN, "2031-8952");
-        bibEntrySpileers2018.setField(StandardField.JOURNAL, "Tijdschrift voor Filosofie");
-        bibEntrySpileers2018.setField(StandardField.PAGES, "625-629");
-        bibEntrySpileers2018.setField(StandardField.URL, "http://doi.org/10.2143/TVF.80.3.3285690");
+                Arguments.of("10.2143/TVF.80.3.3285690",
+                        Optional.of(
+                                new BibEntry(StandardEntryType.Article)
+                                        .withField(StandardField.AUTHOR, "SPILEERS, Steven ")
+                                        .withField(StandardField.PUBLISHER, "Peeters online journals")
+                                        .withField(StandardField.TITLE, "Algemene kroniek")
+                                        .withField(StandardField.YEAR, "2018")
+                                        .withField(StandardField.DOI, "10.2143/TVF.80.3.3285690")
+                                        .withField(StandardField.ISSN, "2031-8952")
+                                        .withField(StandardField.JOURNAL, "Tijdschrift voor Filosofie")
+                                        .withField(StandardField.PAGES, "625-629")
+                                        .withField(StandardField.URL, "http://doi.org/10.2143/TVF.80.3.3285690")
+                        )),
 
-        bibEntryIannarelli2019 = new BibEntry();
-        bibEntryIannarelli2019.setType(StandardEntryType.Article);
-        bibEntryIannarelli2019.setField(StandardField.AUTHOR,
-                                        ""
-                                                            + "Iannarelli Riccardo  and "
-                                                            + "Novello Anna  and "
-                                                            + "Stricker Damien  and "
-                                                            + "Cisternino Marco  and "
-                                                            + "Gallizio Federico  and "
-                                                            + "Telib Haysam  and "
-                                                            + "Meyer Thierry ");
-        bibEntryIannarelli2019.setField(StandardField.PUBLISHER, "AIDIC: Italian Association of Chemical Engineering");
-        bibEntryIannarelli2019.setField(StandardField.TITLE, "Safety in research institutions: how to better communicate the risks using numerical simulations");
-        bibEntryIannarelli2019.setField(StandardField.YEAR, "2019");
-        bibEntryIannarelli2019.setField(StandardField.DOI, "10.3303/CET1977146");
-        bibEntryIannarelli2019.setField(StandardField.JOURNAL, "Chemical Engineering Transactions");
-        bibEntryIannarelli2019.setField(StandardField.PAGES, "871-876");
-        bibEntryIannarelli2019.setField(StandardField.URL, "http://doi.org/10.3303/CET1977146");
-        bibEntryIannarelli2019.setField(StandardField.VOLUME, "77");
-
-        bibEntryCisternino1999 = new BibEntry();
-        bibEntryCisternino1999.setType(StandardEntryType.Article);
-        bibEntryCisternino1999.setField(StandardField.AUTHOR, "Cisternino Paola ");
-        bibEntryCisternino1999.setField(StandardField.PUBLISHER, "Edizioni Otto Novecento");
-        bibEntryCisternino1999.setField(StandardField.TITLE, "Diagramma semantico dei lemmi : casa, parola, silenzio e attesa in È fatto giorno e Margherite e rosolacci di Rocco Scotellaro");
-        bibEntryCisternino1999.setField(StandardField.YEAR, "1999");
-        bibEntryCisternino1999.setField(StandardField.DOI, "10.1400/115378");
-        bibEntryCisternino1999.setField(StandardField.JOURNAL, "Otto/Novecento : rivista quadrimestrale di critica e storia letteraria");
-        bibEntryCisternino1999.setField(StandardField.URL, "http://doi.org/10.1400/115378");
+                Arguments.of("10.3303/CET1977146",
+                        Optional.of(
+                                new BibEntry(StandardEntryType.Article)
+                                        .withField(StandardField.AUTHOR,
+                                                ""
+                                                        + "Iannarelli Riccardo  and "
+                                                        + "Novello Anna  and "
+                                                        + "Stricker Damien  and "
+                                                        + "Cisternino Marco  and "
+                                                        + "Gallizio Federico  and "
+                                                        + "Telib Haysam  and "
+                                                        + "Meyer Thierry ")
+                                        .withField(StandardField.PUBLISHER, "AIDIC: Italian Association of Chemical Engineering")
+                                        .withField(StandardField.TITLE, "Safety in research institutions: how to better communicate the risks using numerical simulations")
+                                        .withField(StandardField.YEAR, "2019")
+                                        .withField(StandardField.DOI, "10.3303/CET1977146")
+                                        .withField(StandardField.JOURNAL, "Chemical Engineering Transactions")
+                                        .withField(StandardField.PAGES, "871-876")
+                                        .withField(StandardField.URL, "http://doi.org/10.3303/CET1977146")
+                                        .withField(StandardField.VOLUME, "77"))),
+                Arguments.of("10.1400/115378",
+                        Optional.of(
+                                new BibEntry(StandardEntryType.Article)
+                                        .withField(StandardField.AUTHOR, "Cisternino Paola ")
+                                        .withField(StandardField.PUBLISHER, "Edizioni Otto Novecento")
+                                        .withField(StandardField.TITLE, "Diagramma semantico dei lemmi : casa, parola, silenzio e attesa in È fatto giorno e Margherite e rosolacci di Rocco Scotellaro")
+                                        .withField(StandardField.ISSN, "0391-2639")
+                                        .withField(StandardField.YEAR, "1999")
+                                        .withField(StandardField.DOI, "10.1400/115378")
+                                        .withField(StandardField.JOURNAL, "Otto/Novecento : rivista quadrimestrale di critica e storia letteraria")
+                                        .withField(StandardField.URL, "http://doi.org/10.1400/115378")
+                        ))
+        );
     }
 
     @Test
@@ -72,26 +79,16 @@ public class MedraTest {
     }
 
     @Test
-    public void testPerformSearchSpileers2018() throws FetcherException {
-        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("10.2143/TVF.80.3.3285690");
-        assertEquals(Optional.of(bibEntrySpileers2018), fetchedEntry);
-    }
-
-    @Test
-    public void testPerformSearchIannarelli2019() throws FetcherException {
-        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("10.3303/CET1977146");
-        assertEquals(Optional.of(bibEntryIannarelli2019), fetchedEntry);
-    }
-
-    @Test
     public void testPerformSearchEmptyDOI() throws FetcherException {
         assertEquals(Optional.empty(), fetcher.performSearchById(""));
     }
 
-    @Test
-    public void testPerformSearchValidReturnNothingDOI() throws FetcherException {
-        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("10.1016/j.bjoms.2007.08.004");
-        assertEquals(Optional.empty(), fetchedEntry);
+    @ParameterizedTest
+    @MethodSource("getDoiBibEntryPairs")
+    public void testDoiBibEntryPairs(String identifier, Optional<BibEntry> expected) throws FetcherException {
+        Optional<BibEntry> fetchedEntry = fetcher.performSearchById(identifier);
+        assertEquals(expected, fetchedEntry);
     }
+
 
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/MedraTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MedraTest.java
@@ -61,7 +61,7 @@ public class MedraTest {
                 Arguments.of("10.1400/115378",
                         Optional.of(
                                 new BibEntry(StandardEntryType.Article)
-                                        .withField(StandardField.AUTHOR, "Cisternino Paola ")
+                                        .withField(StandardField.AUTHOR, "Paola Cisternino")
                                         .withField(StandardField.PUBLISHER, "Edizioni Otto Novecento")
                                         .withField(StandardField.TITLE, "Diagramma semantico dei lemmi : casa, parola, silenzio e attesa in È fatto giorno e Margherite e rosolacci di Rocco Scotellaro")
                                         .withField(StandardField.ISSN, "0391-2639")

--- a/src/test/java/org/jabref/logic/importer/util/JsonReaderTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/JsonReaderTest.java
@@ -1,0 +1,50 @@
+package org.jabref.logic.importer.util;
+
+import java.io.ByteArrayInputStream;
+
+import org.jabref.logic.importer.ParseException;
+
+import kong.unirest.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsonReaderTest {
+
+    @Test
+    void nullStreamThrowsNullPointerException() {
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            JsonReader.toJsonObject(null);
+        });
+    }
+
+    @Test
+    void invalidJsonThrowsParserException() {
+        Assertions.assertThrows(ParseException.class, () -> {
+            JsonReader.toJsonObject(new ByteArrayInputStream("invalid JSON".getBytes()));
+        });
+    }
+
+    @Test
+    void emptyStringResultsInEmptyObject() throws Exception {
+        JSONObject result = JsonReader.toJsonObject(new ByteArrayInputStream("".getBytes()));
+        assertEquals("{}", result.toString());
+    }
+
+    @Test
+    void arrayThrowsParserException() {
+        // Reason: We expect a JSON object, not a JSON array
+        Assertions.assertThrows(ParseException.class, () -> {
+            JsonReader.toJsonObject(new ByteArrayInputStream("[]".getBytes()));
+        });
+    }
+
+    @Test
+    void exampleJsonResultsInSameJson() throws Exception {
+        String input = "{\"name\":\"test\"}";
+        JSONObject result = JsonReader.toJsonObject(new ByteArrayInputStream(input.getBytes()));
+        assertEquals(input, result.toString());
+    }
+
+}


### PR DESCRIPTION
I wanted to "quickly" suggest concrete improvements to https://github.com/JabRef/jabref/pull/6641.

It turned out to be harder.

Here my results. Three different commits touching different aspects:

1. Rewrite JsonReader to return an empty Json object
2. Rewrite Medra and CrossRef fetcher to use the Json object
3. Rewrite fetcher hierarchy to use new method "getUrlDownloadForIdentifier" (this is waht you really wanted I think) (combined with the last commit)
4. Rewrite MedraTest to use Paramterized Tests
5. Fix obsolete spaces in the returned names (and fixes the name "Paola Cisternino", who has "Paola" as first name, not as last name -- according to https://www.torrossa.com/en/resources/an/2201053)  
   ![grafik](https://user-images.githubusercontent.com/1366654/86771042-e2500380-c051-11ea-96b4-c19d649c5e81.png)
